### PR TITLE
Add gitignore to generated app

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -1,0 +1,3 @@
+node_modules
+tmp
+dist


### PR DESCRIPTION
This fixes the Ember CLI “maxBuffer” error. When adding files to git,
the list of added files is written to stdout. Because node_modules was
not in .gitignore, that list exceeded execa’s 10MB buffer. (lol)