### PR TITLE
Web Component support

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -16,6 +16,7 @@
     "@glimmer/application": "^0.3.4",
     "@glimmer/component": "^0.3.3",
     "@glimmer/resolver": "^0.2.0",
+    "@glimmer/web-component": "^0.1.0",
     "ember-cli": "2.10.0",
     "typescript": "^2.1.5"
   },

--- a/files/package.json
+++ b/files/package.json
@@ -12,11 +12,10 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@glimmer/application-pipeline": "^0.3.1",
     "@glimmer/application": "^0.3.4",
+    "@glimmer/application-pipeline": "^0.3.1",
     "@glimmer/component": "^0.3.3",
     "@glimmer/resolver": "^0.2.0",
-    "@glimmer/web-component": "^0.1.0",
     "ember-cli": "2.10.0",
     "typescript": "^2.1.5"
   },

--- a/files/src/index.ts
+++ b/files/src/index.ts
@@ -1,6 +1,5 @@
 import App from './main';
 import { ComponentManager, setPropertyDidChange } from '@glimmer/component';
-import initializeCustomElements from '@glimmer/web-component';
 
 const app = new App();
 const containerElement = document.getElementById('app');
@@ -18,5 +17,3 @@ app.registerInitializer({
 app.boot();
 
 app.renderComponent('<%= component %>', containerElement, null);
-
-initializeCustomElements(app, ['<%= component %>']);

--- a/files/src/index.ts
+++ b/files/src/index.ts
@@ -1,5 +1,6 @@
 import App from './main';
 import { ComponentManager, setPropertyDidChange } from '@glimmer/component';
+import initializeCustomElements from '@glimmer/web-component';
 
 const app = new App();
 const containerElement = document.getElementById('app');
@@ -17,3 +18,5 @@ app.registerInitializer({
 app.boot();
 
 app.renderComponent('<%= component %>', containerElement, null);
+
+initializeCustomElements(app, ['<%= component %>']);

--- a/index.js
+++ b/index.js
@@ -19,6 +19,29 @@ module.exports = {
     return {
       __component__() { return options.locals.component }
     }
+  },
+
+  afterInstall(options) {
+    if (options.webComponent) {
+      this._installWebComponentSupport(options);
+    }
+  },
+
+  _installWebComponentSupport(options) {
+    let name = options.entity.name;
+    let component = componentize(name);
+
+    this.addPackageToProject('@glimmer/web-component');
+    this.insertIntoFile(
+      'src/index.ts',
+      "import initializeCustomElements from '@glimmer/web-component';",
+      { after: "import { ComponentManager, setPropertyDidChange } from '@glimmer/component';\n" }
+    ).then(() => {
+      return this.insertIntoFile(
+        'src/index.ts',
+        `initializeCustomElements(app, ['${component}']);\n`
+      );
+    });
   }
 };
 


### PR DESCRIPTION
This adds support for Web Components but does not add one to the index.html.

Relies on https://github.com/glimmerjs/glimmer-application-pipeline/pull/25

- [x] WC support
- [x] Optional WC support
- [ ] Bump @glimmer/application-pipeline