### PR TITLE
Introduce public dir for images, robot.txt, favicon, etc.

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@glimmer/application": "^0.4.0",
-    "@glimmer/application-pipeline": "^0.5.1",
+    "@glimmer/application-pipeline": "^0.5.2",
     "@glimmer/component": "^0.3.8",
     "@glimmer/resolver": "^0.3.0",
     "ember-cli": "2.12.1",

--- a/files/public/robots.txt
+++ b/files/public/robots.txt
@@ -1,0 +1,3 @@
+# http://www.robotstxt.org
+User-agent: *
+Disallow:


### PR DESCRIPTION
@glimmer/application-pipeline@0.5.2 supports a public dir. By adding one to the blueprint, together with a default placeholder robots.txt, the potential usage should be clear.