### PR TITLE
Prevent initial render + double rerender

### DIFF
--- a/files/src/index.ts
+++ b/files/src/index.ts
@@ -14,6 +14,6 @@ app.registerInitializer({
   }
 });
 
-app.boot();
-
 app.renderComponent('<%= component %>', containerElement, null);
+
+app.boot();


### PR DESCRIPTION
Before:

<img width="1392" alt="screen shot 2017-03-31 at 11 20 56 pm" src="https://cloud.githubusercontent.com/assets/671032/24576040/3f148e88-1669-11e7-96b1-93e619672f84.png">

After:

<img width="1173" alt="screen shot 2017-03-31 at 11 19 35 pm" src="https://cloud.githubusercontent.com/assets/671032/24576043/45494b9a-1669-11e7-8785-2d481be3b601.png">

cc @GavinJoyce @chadhietala re: https://github.com/glimmerjs/glimmer-application/issues/43#issuecomment-290741098