### PR TITLE
`npm run build` should produce a production build by default

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build",
+    "build": "ember build -e production",
     "start": "ember server",
     "test": "ember test"
   },


### PR DESCRIPTION
See discussion in #12 