### PR TITLE
Remove duplicate dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "ember-cli-string-utils": "^1.1.0"
   },
   "devDependencies": {
-    "ember-cli-string-utils": "^1.1.0",
     "ember-cli-valid-component-name": "^1.0.0"
   }
 }


### PR DESCRIPTION
Listing something in dependencies and devDependencies results in bizarre behavior and is not needed/useful.