### PR TITLE
Add allowJs to default blueprint tsconfig.json.

### DIFF
--- a/files/tsconfig.json
+++ b/files/tsconfig.json
@@ -5,7 +5,8 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "moduleResolution": "node",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "allowJs": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Our pipeline actually includes `*.js` files (we transpile `*.hbs` -> `*.js` for example).