### PR TITLE
Point ember-cli dependency to Canary channel

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -16,7 +16,7 @@
     "@glimmer/application-pipeline": "^0.5.2",
     "@glimmer/component": "^0.3.8",
     "@glimmer/resolver": "^0.3.0",
-    "ember-cli": "2.12.1",
+    "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-inject-live-reload": "^1.6.1",
     "typescript": "^2.2.2"
   },


### PR DESCRIPTION
This allows `ember init -b @glimmer/blueprint`, among others? :X
Also keeps symmetry with having to ask for Canary channel for project creation.