### PR TITLE
Allow usage of blueprint within a blueprinted project.

### DIFF
--- a/blueprints/@glimmer/blueprint/index.js
+++ b/blueprints/@glimmer/blueprint/index.js
@@ -1,0 +1,26 @@
+'use strict';
+const path = require('path');
+const MainBlueprint = require('../../../index');
+
+/*
+  Create an "addon blueprint" that simply defers to our
+  top level entry point as the blueprint.
+
+  This is basically just a work around for
+  https://github.com/ember-cli/ember-cli/issues/6952.
+
+  Once that issue is fixed and released we can remove:
+
+    * ember-addon keyword in package.json
+    * ember-addon key in package.json
+    * ember-addon-main.js file
+    * blueprints/ folder
+ */
+module.exports = Object.assign({}, MainBlueprint, {
+  init() {
+    this._super.init.apply(this, arguments);
+
+    this.path = path.join(__dirname, '..', '..', '..');
+    this.name = '@glimmer/blueprint';
+  }
+});

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/*
+  Create an "addon blueprint" that simply defers to our
+  top level entry point as the blueprint.
+
+  This is basically just a work around for
+  https://github.com/ember-cli/ember-cli/issues/6952.
+
+  Once that issue is fixed and released we can remove:
+
+  * ember-addon keyword in package.json
+  * ember-addon key in package.json
+  * ember-addon-main.js file
+  * blueprints/ folder
+  */
+module.exports = {
+  name: '@glimmer/blueprint'
+};

--- a/files/package.json
+++ b/files/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@glimmer/application": "^0.4.0",
     "@glimmer/application-pipeline": "^0.5.2",
+    "@glimmer/blueprint": "^0.1.12",
     "@glimmer/component": "^0.3.8",
     "@glimmer/resolver": "^0.3.0",
     "ember-cli": "github:ember-cli/ember-cli",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "git+https://github.com/glimmerjs/glimmer-blueprint.git"
   },
   "keywords": [
-    "ember-blueprint"
+    "ember-blueprint",
+    "ember-addon"
   ],
   "author": "Tom Dale <tom@tomdale.net>",
   "license": "MIT",
@@ -24,5 +25,8 @@
   },
   "devDependencies": {
     "ember-cli-valid-component-name": "^1.0.0"
+  },
+  "ember-addon": {
+    "main": "ember-addon-main.js"
   }
 }


### PR DESCRIPTION
Prior to these changes running `ember init -b @glimmer/blueprint` would always download the `latest` release from `npm`'s registry for `@glimmer/blueprint`. This means that it is impossible to actually control your upgrading process.

This change makes this package *both* a stand alone blueprint package *and* an addon. The addon creates a blueprint for `@glimmer/blueprint` so that now `ember init -b @glimmer/blueprint` will use whatever version of `@glimmer/blueprint` that you happen to have installed. This mirrors the way ember-cli upgrades work (where you first update the version of ember-cli in the project, then you run `ember init` with that version).

Ultimately, this commit should be able to be revertted once the upstream issue is resolved: ember-cli/ember-cli#6952.
