### PR TITLE
Add addons for fingerprinting and JS minification.

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -17,8 +17,10 @@
     "@glimmer/blueprint": "^0.1.12",
     "@glimmer/component": "^0.3.8",
     "@glimmer/resolver": "^0.3.0",
+    "broccoli-asset-rev": "^2.5.0",
     "ember-cli": "github:ember-cli/ember-cli",
     "ember-cli-inject-live-reload": "^1.6.1",
+    "ember-cli-uglify": "^1.2.0",
     "typescript": "^2.2.2"
   },
   "engines": {


### PR DESCRIPTION
This is in support of https://github.com/glimmerjs/glimmer-application-pipeline/pull/81.  Once this lands and releases, we can land that PR (which deprecates falling back to the built-in fingerprinting and minification).