### PR TITLE
Add ember-cli-sass addon to default blueprint.

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -20,6 +20,7 @@
     "ember-cli": "^2.14.0-beta.2",
     "ember-cli-inject-live-reload": "^1.6.1",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-sass": "^6.2.0",
     "typescript": "^2.2.2"
   },
   "engines": {


### PR DESCRIPTION
Versions of @glimmer/application-pipeline after 0.7.0 will issue a deprecation warning when SASS files are present but ember-cli-sass is not.

This squelches the deprecation warning.