### PR TITLE
don't ignore tmp/.metadata_never_index

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -1,3 +1,4 @@
 node_modules
-tmp
+tmp/*
+!tmp/.metadata_never_index
 dist


### PR DESCRIPTION
Related to #42.

Scenario: Create new project, check in, someone else clones, this file isn't there.

Seems like the intent of the file is lost if it is gitignore'd?