### PR TITLE
use single quotes in ts

### DIFF
--- a/files/src/ui/components/__component__/component.ts
+++ b/files/src/ui/components/__component__/component.ts
@@ -1,4 +1,4 @@
-import Component from "@glimmer/component";
+import Component from '@glimmer/component';
 
 export default class <%= className %> extends Component {
 


### PR DESCRIPTION
I asked in slack if this was the new convention, and it seems like double quotes may have been inadvertently added by VSCode codegen.

Feel free to close if it is not the case.