### PR TITLE
add ember-cli-dependency-checker to blueprint

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -18,6 +18,7 @@
     "@glimmer/resolver": "^0.3.0",
     "broccoli-asset-rev": "^2.5.0",
     "ember-cli": "^2.14.0-beta.2",
+    "ember-cli-dependency-checker": "^2.0.1",
     "ember-cli-inject-live-reload": "^1.6.1",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-sass": "^6.2.0",


### PR DESCRIPTION
I ran into a problem that this would have solved, if we want it here.