### PR TITLE
Do not include yarn.lock in upgrades

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,16 @@ module.exports = {
     }
   },
 
+  files() {
+    let files = this._super.files.apply(this, arguments);
+
+    if (this.project.pkg.name) {
+      files = files.filter((file) => file !== 'yarn.lock');
+    }
+    
+    return files;
+  },
+
   afterInstall(options) {
     if (options.webComponent) {
       return this._installWebComponentSupport(options);

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
   files() {
     let files = this._super.files.apply(this, arguments);
 
-    if (this.project.pkg.name) {
+    if (this._shouldIncludeYarnLockInFiles()) {
       files = files.filter((file) => file !== 'yarn.lock');
     }
     
@@ -61,6 +61,10 @@ module.exports = {
       addPackagePromise,
       indexTSPromise
     ]);
+  },
+
+  _shouldIncludeYarnLockInFiles() {
+    return !!this.project.pkg.name;
   }
 };
 


### PR DESCRIPTION
Right now `yarn.lock` is included in upgrades done via `ember init`. This is pretty unnecessary since the file is empty anyway and if you try to look at the diff it will take a couple of seconds.

@rwjblue suggested to check if a non empty yarn.lock file already exists, but in my opinion this could be annoying if you don't want to use yarn since the lockfile will appear again after every upgrade.

So for now I check if `project.pkg.name` is set which is the case for `ember init` in existing projects, but not for `ember new` or `ember init` in empty folders.