### PR TITLE
Update to latest version of ember-cli-uglify.

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -24,7 +24,7 @@
     "ember-cli-dependency-checker": "^2.0.1",
     "ember-cli-inject-live-reload": "^1.6.1",
     "ember-cli-sass": "^6.2.0",
-    "ember-cli-uglify": "^1.2.0",
+    "ember-cli-uglify": "^2.0.0-beta.1",
     "qunitjs": "^2.3.3",
     "typescript": "^2.2.2"
   },


### PR DESCRIPTION
Has much better support for ES6+ features.