### PR TITLE
shorten -e production to -prod

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build -e production",
+    "build": "ember build -prod",
     "start": "ember server",
     "test": "ember test"
   },


### PR DESCRIPTION
This is merely a convenience. I figured if we are already shortening "--environment production", might as well shorten it further.