### PR TITLE
Make it easier to upgrade

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -1,0 +1,3 @@
+{
+  "blueprint": "@glimmer/blueprint"
+}


### PR DESCRIPTION
This allows you to type `ember init` instead of `ember init -b @glimmer/blueprint` every time