### PR TITLE
Support Glimmer 0.8.0

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -15,6 +15,7 @@
     "@glimmer/application": "^0.8.0-alpha.7",
     "@glimmer/application-pipeline": "^0.8.0",
     "@glimmer/blueprint": "^0.5.0",
+    "@glimmer/component": "^0.8.0-alpha.7",
     "@glimmer/inline-precompile": "^1.0.0",
     "@glimmer/resolver": "^0.3.0",
     "@glimmer/test-helpers": "^0.30.0",

--- a/files/package.json
+++ b/files/package.json
@@ -12,7 +12,7 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@glimmer/application": "^0.7.2",
+    "@glimmer/application": "^0.8.0-alpha.7",
     "@glimmer/application-pipeline": "^0.8.0",
     "@glimmer/blueprint": "^0.5.0",
     "@glimmer/inline-precompile": "^1.0.0",

--- a/files/package.json
+++ b/files/package.json
@@ -12,10 +12,10 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@glimmer/application": "^0.8.0-alpha.9",
+    "@glimmer/application": "^0.8.0",
     "@glimmer/application-pipeline": "^0.9.0",
     "@glimmer/blueprint": "^0.6.0",
-    "@glimmer/component": "^0.8.0-alpha.9",
+    "@glimmer/component": "^0.8.0",
     "@glimmer/inline-precompile": "^1.0.0",
     "@glimmer/resolver": "^0.4.1",
     "@glimmer/test-helpers": "^0.30.0",

--- a/files/package.json
+++ b/files/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@glimmer/application": "^0.8.0-alpha.9",
     "@glimmer/application-pipeline": "^0.9.0",
-    "@glimmer/blueprint": "^0.5.0",
+    "@glimmer/blueprint": "^0.6.0",
     "@glimmer/component": "^0.8.0-alpha.9",
     "@glimmer/inline-precompile": "^1.0.0",
     "@glimmer/resolver": "^0.4.1",

--- a/files/package.json
+++ b/files/package.json
@@ -12,12 +12,12 @@
     "test": "ember test"
   },
   "devDependencies": {
-    "@glimmer/application": "^0.8.0-alpha.7",
-    "@glimmer/application-pipeline": "^0.8.0",
+    "@glimmer/application": "^0.8.0-alpha.9",
+    "@glimmer/application-pipeline": "^0.9.0",
     "@glimmer/blueprint": "^0.5.0",
-    "@glimmer/component": "^0.8.0-alpha.7",
+    "@glimmer/component": "^0.8.0-alpha.9",
     "@glimmer/inline-precompile": "^1.0.0",
-    "@glimmer/resolver": "^0.3.0",
+    "@glimmer/resolver": "^0.4.1",
     "@glimmer/test-helpers": "^0.30.0",
     "@types/qunit": "^2.0.31",
     "broccoli-asset-rev": "^2.5.0",

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const dasherize = require('ember-cli-string-utils').dasherize;
-const stringUtils = require('ember-cli-string-utils');
+const classify = require('ember-cli-string-utils').classify;
 
 module.exports = {
   description: 'Ember CLI blueprint for initializing a new Glimmer application',
@@ -13,8 +13,8 @@ module.exports = {
 
   locals(options) {
     let name = dasherize(options.entity.name);
-    let component = componentize(name);
-    let className = stringUtils.classify(options.entity.name);
+    let component = classify(name);
+    let className = classify(options.entity.name);
 
     return { name, className, component };
   },

--- a/index.js
+++ b/index.js
@@ -31,19 +31,32 @@ module.exports = {
     if (this._shouldIncludeYarnLockInFiles()) {
       files = files.filter((file) => file !== 'yarn.lock');
     }
-    
+
     return files;
   },
 
   afterInstall(options) {
     if (options.webComponent) {
+      this._validateWebComponentName(options);
       return this._installWebComponentSupport(options);
     }
   },
 
+  _validateWebComponentName(options) {
+    let customElementName = options.webComponent;
+
+    if(typeof customElementName !== 'string') {
+      throw 'You must provide a name for the web component, eg. `--web-component=button-list`';
+    }
+
+    if(!hasDash(customElementName)) {
+      throw `The web component name must contain a dash. You provided "${customElementName}"` ;
+    }
+  },
+
   _installWebComponentSupport(options) {
-    let name = options.entity.name;
-    let component = componentize(name);
+    let customElementName = options.webComponent;
+    let glimmerComponentName = options.entity.name;
 
     let addPackagePromise = this.addPackageToProject('@glimmer/web-component');
     let indexTSPromise = this.insertIntoFile(
@@ -53,7 +66,7 @@ module.exports = {
     ).then(() => {
       return this.insertIntoFile(
         'src/index.ts',
-        `initializeCustomElements(app, ['${component}']);\n`
+        `initializeCustomElements(app, { '${customElementName}': '${glimmerComponentName}' });\n`
       );
     });
 
@@ -67,13 +80,6 @@ module.exports = {
     return !!this.project.pkg.name;
   }
 };
-
-// Component names must have at least one dash, so we suffix the component name
-// with `-app` if it doesn't have one. E.g.: `avatar` -> `avatar-app`
-function componentize(name) {
-  let dasherized = dasherize(name);
-  return hasDash(dasherized) ? dasherized : `${dasherized}-app`;
-}
 
 function hasDash(string) {
   return string.indexOf('-') > -1;


### PR DESCRIPTION
https://github.com/glimmerjs/glimmer-blueprint/tree/support-0.8.0-application with some additional changes

TODO:

 * [x] Find out why the app is just rendering `component` and fix (this happens even after manually renaming the root component)
 * [x] Update root component to be capitalized when generating app
 * [x] Bump https://github.com/glimmerjs/glimmer-application-pipeline and update `files/package.json` to new version
 * [x] verify that helpers work
 * [x] verify that web components work : https://github.com/glimmerjs/glimmer-blueprint/pull/66#issuecomment-336375245
 * [x] verify that app tests work

You can test this as follows:

`ember new MyApp -b ./path/to/glimmer-blueprint`
`ember new MyApp -b ./path/to/glimmer-blueprint --web-component=my-app`
