### PR TITLE
Use CamelCase component name in the Web Component setup

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
 
   _installWebComponentSupport(options) {
     let customElementName = options.webComponent;
-    let glimmerComponentName = options.entity.name;
+    let glimmerComponentName = classify(options.entity.name);
 
     let addPackagePromise = this.addPackageToProject('@glimmer/web-component');
     let indexTSPromise = this.insertIntoFile(


### PR DESCRIPTION
I had problems using glimmerjs > 0.8 with the `--web-component` option. I've built the project and tested the component in a custom web page, but the component wasn't rendered.

I've found the blueprint was generating an `index.ts` file with the following line:

```ts
initializeCustomElements(app, { 'my-component': 'my-component' });
```

However, I had to manually change to the following to have the component working 

```ts
initializeCustomElements(app, { 'my-component': 'MyComponent' });
```

This follows the changes made in the `glimmer-web-component` package
(https://github.com/glimmerjs/glimmer-web-component/pull/22)