### PR TITLE
inject blueprint version at time of generation

### DIFF
--- a/files/package.json
+++ b/files/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@glimmer/application": "^0.8.0",
     "@glimmer/application-pipeline": "^0.9.0",
-    "@glimmer/blueprint": "^0.6.0",
+    "@glimmer/blueprint": "~<%= blueprintVersion %>",
     "@glimmer/component": "^0.8.0",
     "@glimmer/inline-precompile": "^1.0.0",
     "@glimmer/resolver": "^0.4.1",

--- a/index.js
+++ b/index.js
@@ -15,8 +15,14 @@ module.exports = {
     let name = dasherize(options.entity.name);
     let component = classify(name);
     let className = classify(options.entity.name);
+    let blueprintVersion = require('./package').version;
 
-    return { name, className, component };
+    return {
+      name,
+      className,
+      component,
+      blueprintVersion
+    };
   },
 
   fileMapTokens(options) {


### PR DESCRIPTION
This is what ember cli does.

* switches to ~ instead of ^
* will help with [ember-cli-update](https://github.com/kellyselden/ember-cli-update) version detection