### PR TITLE
Ensure glimmerjs/glimmer-blueprint-output is consistently published.

### DIFF
--- a/dev/add-to-output-repos.sh
+++ b/dev/add-to-output-repos.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# so you can run this script from any folder and it will find the tmp dir
+cd "`git rev-parse --show-toplevel`"
+
+mkdir -p tmp
+cd tmp
+
+branch=master
+
+VERSION=`git tag --list --points-at HEAD`
+
+command=new
+repo_folder=glimmer-blueprint-output
+local_folder=my-app
+
+git clone git@github.com:glimmerjs/$repo_folder.git --branch $branch
+pushd $repo_folder
+git rm -rf .
+ember $command $local_folder -skip-bower --skip-npm --skip-git
+cp -r $local_folder/ .
+rm -r $local_folder
+
+git add --all
+git commit --allow-empty --message $VERSION
+git tag $VERSION
+git push
+git push --tags
+
+popd
+rm -rf $repo_folder

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Ember CLI blueprint for initializing a new Glimmer application.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postversion": "sh ./dev/add-to-output-repos.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Mostly copied the shell commands from:

https://github.com/ember-cli/ember-cli/blob/v2.16.2/dev/add-to-output-repos.sh