### PR TITLE
Remove launching of Firefox from testem

### DIFF
--- a/files/testem.json
+++ b/files/testem.json
@@ -3,5 +3,5 @@
   "src_files": ["src/**/*"],
   "serve_files": ["index.js"],
   "disable_watching": true,
-  "launch_in_ci": ["Firefox", "Chrome"]
+  "launch_in_ci": ["Chrome"]
 }


### PR DESCRIPTION
It's annoying that you can't run `ember test` without getting an error on a clean project if you don't have Firefox installed. The same is probably true of Chrome, but I would *guess* most devs have Chrome installed on their machines, which is why embers testem setup only uses chrome.